### PR TITLE
fix: `sort_by` now correctly sorts in descend for '.upper', etc.

### DIFF
--- a/tests/testthat/test-summarize_data.R
+++ b/tests/testthat/test-summarize_data.R
@@ -44,7 +44,7 @@ testthat::test_that("summarize_data", {
       ) |>
       dplyr::slice(1) |>
       dplyr::pull(.count),
-    expected = 129)
+    expected = 126)
 
   testthat::expect_equal(
     saros:::summarize_data(


### PR DESCRIPTION
closes #260 