### PR TITLE
Replace mesos var check with total filename check

### DIFF
--- a/R/draft_report.R
+++ b/R/draft_report.R
@@ -512,7 +512,7 @@
 #'   file paths. This will mean that files with cache (hash suffixes are added) will
 #'   quickly breach this limit. When set, a warning will be returned if files are found
 #'   to be longer than this threshold. Also note that spaces count as three characters
-#'   due to its URL-conversion: %20
+#'   due to its URL-conversion: %20. To avoid test, set to Inf
 #'
 #' @param mesos_first *mesos first*
 #'

--- a/man/draft_report.Rd
+++ b/man/draft_report.Rd
@@ -502,6 +502,16 @@ Whereas \code{max_width_file} truncates the file name, this argument truncates
 the folder name. It will not impact the report or chapter names in website,
 only the folders.}
 
+\item{max_path_warning_threshold}{\emph{Maximum number of characters in paths warning}
+
+\verb{scalar<integer>} // \emph{default:} \code{260} (\code{optional})
+
+Microsoft has set an absolute limit of 260 characters for its Sharepoint/OneDrive
+file paths. This will mean that files with cache (hash suffixes are added) will
+quickly breach this limit. When set, a warning will be returned if files are found
+to be longer than this threshold. Also note that spaces count as three characters
+due to its URL-conversion: \%20. To avoid test, set to Inf}
+
 \item{open_after_drafting}{\emph{Whether to open index.qmd}
 
 \verb{scalar<logical>} // \emph{default:} \code{FALSE} (\code{optional})

--- a/man/draft_report.Rd
+++ b/man/draft_report.Rd
@@ -77,6 +77,7 @@ draft_report(
   max_width_obj = 128,
   max_width_file = 64,
   max_clean_folder_name = 12,
+  max_path_warning_threshold = 260,
   open_after_drafting = FALSE,
   organize_by = c("chapter", ".variable_label_prefix_dep", ".variable_name_indep",
     ".element_name"),


### PR DESCRIPTION
Instead set a check of all file paths after completion. Although this is a rather late check, it is more precise, and more relevant as mesos_var levels are no longer used directly as file and folder names as they are sanitized. The threshold is set with max_path_warning_threshold.