### PR TITLE
Fix GitHub issue #464: makeme() failures for sigtest_table

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,17 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "Install package",
+			"type": "shell",
+			"command": "C:/Program Files/R/R-4.5.1/bin/x64/R.exe",
+			"args": [
+				"--no-echo",
+				"--no-restore",
+				"-e",
+				"devtools::install()"
+			],
+			"group": "build"
+		}
+	]
+}

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,8 @@
 -   Updated documentation reference from `ggplot2::theme_set()` to `ggplot2::set_theme()` due to ggplot 4.0.0.
 -   Fix: Corrected double NA check logic in `check_bool()` function - removed redundant condition that made validation always pass for NA values
 -   Fix: Improved NULL and NA handling in `glue_together_range()` to prevent edge case failures with empty or invalid data ranges
-
+-   Fix: Resolved issue #464 - `makeme()` failures for sigtest_table when dep and indep variables overlap. Now automatically excludes indep variables from dep selection to prevent conflicts
+-   Fix: Improved robustness of `check_no_duplicated_label_suffix()` to handle empty data frames and missing columns gracefully
 -   Dev: Added VS Code configuration for improved development experience
 
 # saros 1.5.4

--- a/R/check_no_duplicated_label_suffix.R
+++ b/R/check_no_duplicated_label_suffix.R
@@ -2,6 +2,30 @@ check_no_duplicated_label_suffix <- function(
   data_summary,
   error_on_duplicates = TRUE
 ) {
+  # Check if data_summary is a valid data frame
+  if (!is.data.frame(data_summary)) {
+    cli::cli_warn(
+      "data_summary is not a data frame, skipping duplicate label check"
+    )
+    return()
+  }
+
+  # Check if required column exists
+  if (!".variable_label" %in% colnames(data_summary)) {
+    cli::cli_warn(
+      "Column '.variable_label' not found in data_summary, skipping duplicate label check"
+    )
+    return()
+  }
+
+  # Check if data_summary is empty
+  if (nrow(data_summary) == 0) {
+    cli::cli_warn(
+      "data_summary is empty (0 rows), skipping duplicate label check"
+    )
+    return()
+  }
+
   duplicates <-
     data_summary |>
     dplyr::grouped_df(vars = c(".variable_label")) |>
@@ -9,6 +33,7 @@ check_no_duplicated_label_suffix <- function(
       dplyr::n_distinct(.data[[".variable_name"]], na.rm = FALSE) > 1
     ) |>
     dplyr::ungroup()
+
   if (nrow(duplicates) > 0 && !all(is.na(duplicates[[".variable_label"]]))) {
     msg <- "Found duplicated variable labels: {unique(duplicates[['.variable_label']])}"
     if (isTRUE(error_on_duplicates)) {

--- a/R/makeme.R
+++ b/R/makeme.R
@@ -492,6 +492,27 @@ makeme <-
     args$data <- data # reinsert after check_options
     args$dep <- names(dep_pos)
     args$indep <- names(indep_pos)
+    
+    # Remove indep variables from dep to prevent overlap conflicts
+    if (length(args$indep) > 0 && length(args$dep) > 0) {
+      overlapping_vars <- intersect(args$dep, args$indep)
+      if (length(overlapping_vars) > 0) {
+        cli::cli_inform(c(
+          "i" = "Variables {.var {overlapping_vars}} were selected for both dep and indep.",
+          "i" = "Automatically excluding them from dep to prevent conflicts."
+        ))
+        args$dep <- setdiff(args$dep, args$indep)
+        
+        # Check if we have any dep variables left
+        if (length(args$dep) == 0) {
+          cli::cli_abort(c(
+            "x" = "After removing overlapping variables, no dependent variables remain.",
+            "i" = "Please adjust your dep selection to exclude indep variables, e.g., {.code dep = c(where(~is.factor(.x)), -{args$indep})}"
+          ))
+        }
+      }
+    }
+    
     args$showNA <- args$showNA[1]
     args$data_label <- args$data_label[1]
     args$type <- eval(args$type)[1]


### PR DESCRIPTION
Resolves GitHub issue #464 where makeme() was failing for sigtest_table when dep and indep variables overlap.

Problem: When using makeme() with dep = where(~is.factor(.x)) and indep = erfaring3 (where erfaring3 is also a factor), the function failed because erfaring3 was selected in both dep and indep, causing conflicts.

Solution: Added automatic conflict resolution that detects overlapping variables and excludes indep variables from dep selection to prevent conflicts.

Technical Changes:
- Enhanced makeme() function with overlap detection
- Improved check_no_duplicated_label_suffix() for better edge case handling  
- Added informative user messages for automatic exclusions
- Comprehensive validation for empty data frames

Testing: Original failing case now works correctly, all existing functionality preserved.

Fixes #464