### PR TITLE
Fix txt_from_cat_mesos_plots issues with second group values and bina…

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@
 
 ## Bug Fixes
 -   Fixed issue #518 where `crowd_plots_as_tabset()` with `save = NULL` produced cryptic "object 'caption' not found" error. Added proper validation to ensure `save` parameter is a single logical value (TRUE or FALSE)
+-   Fixed `txt_from_cat_mesos_plots()` where second group (others) proportions incorrectly became zero. Refactored to process each variable separately, ensuring both groups' proportions are correctly calculated per variable
+-   Fixed `txt_from_cat_mesos_plots()` where `n_highest_categories=2` with binary (2-category) variables summed all categories to 1.0, producing uninformative results. Now only applies `n_highest_categories` when the variable has more categories than the threshold, otherwise uses only the single highest/lowest category
 -   Fixed issue #511 where `x_axis_label_width` parameter had no effect in `int_plot_html` when no independent variable was present. The `apply_label_wrapping()` function now correctly wraps `.variable_label` when `indep_length == 0`
 -   Fixed issue #512 where `makeme()` with multiple crowds produced identical plots instead of crowd-specific filtered data. The `process_crowd_data()` function now correctly passes filtered `subset_data` to `make_content()` for each crowd, ensuring each plot displays statistics computed from only that crowd's data subset
 -   Fixed `txt_from_cat_mesos_plots()` to handle cases where `.category_order` contains NA values by using `na.rm = TRUE` when calculating max values, preventing "NA/NaN argument" errors

--- a/man/txt_from_cat_mesos_plots.Rd
+++ b/man/txt_from_cat_mesos_plots.Rd
@@ -37,7 +37,8 @@ Each must contain columns: \code{.variable_label}, \code{.category}, \code{.cate
 between groups to generate text. Differences below this threshold are ignored.}
 
 \item{n_highest_categories}{Integer. Number of top categories to include in the
-comparison (default 1). Categories are selected based on \code{.category_order}.}
+comparison (default 1). Categories are selected based on \code{.category_order}.
+Only applied if the variable has more categories than this value.}
 
 \item{flip_to_lowest_categories}{Logical. If TRUE, compare lowest categories instead
 of highest (default FALSE).}


### PR DESCRIPTION
…ry variables

Issue a: Fixed second group proportions becoming zero
- Refactored to process each variable separately in a loop
- Ensures both groups' proportions are correctly calculated per variable
- Moved variable-specific filtering inside lapply loop

Issue b: Fixed n_highest_categories with binary variables
- Added logic to check if n_categories <= n_highest_categories
- When true, uses only single highest/lowest category instead of summing all
- Prevents uninformative results where binary variables sum to 1.0
- Only applies n_highest_categories when variable has more categories

Tests:
- Added test for second group proportion calculation
- Added test for binary variable handling with n_highest_categories=2
- Added test for multi-category variables with n_highest_categories=2
- Added test for mixed scenarios with different category counts

Updated documentation to clarify n_highest_categories behavior