### PR TITLE
Fix fig_height_h_barchart2() to support int_plot_html with indep vari…

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # saros 1.6.1.9000 (dev)
 
 ## Bug Fixes
+-   Fixed `fig_height_h_barchart2()` to properly handle `int_plot_html` plots with independent variables. The function now forwards to `fig_height_h_barchart()` with appropriate parameters for interval plots, returning the `max` parameter value (default 12) while allowing user customization, instead of erroring with "only supports a single indep variable"
 -   Fixed `n_range2()` for `int_plot_html` plots to report N range per dependent variable instead of total count across all variables. Now correctly calculates sample size separately for each variable and reports the range (e.g., [250-299] when variables have different amounts of missing data)
 
 

--- a/R/fig_height_h_barchart.R
+++ b/R/fig_height_h_barchart.R
@@ -403,17 +403,47 @@ fig_height_h_barchart2 <- # Returns a numeric value
     fixed_constant = 0,
     figure_width_in_cm = 14,
     margin_in_cm = 0,
-    max = 8,
+    max = 12,
     min = 1
   ) {
     data <- ggobj$data
-    # gg <- ggobj
 
     if (!(inherits(data, "data.frame") && nrow(data) > 0)) {
       cli::cli_warn(
         "{.arg ggobj} must be a ggplot2-object with a nrow>0 data in it. Returning {.arg min}: {.val {min}}."
       )
       return(min)
+    }
+
+    # Check if this is an int_plot_html (has .value instead of .category)
+    if (".value" %in% colnames(data) && !".category" %in% colnames(data)) {
+      # int_plot_html uses simple default height
+      # Forward to fig_height_h_barchart with minimal parameters
+      max_value <- max
+      min_value <- min
+
+      n_y <- dplyr::n_distinct(data$.variable_name)
+      max_chars_labels_y <- base::max(
+        nchar(as.character(data$.variable_label)),
+        na.rm = TRUE
+      )
+
+      return(
+        fig_height_h_barchart(
+          n_y = n_y,
+          n_cats_y = 1, # int_plot_html doesn't have categories
+          max_chars_labels_y = max_chars_labels_y,
+          max_chars_cats_y = 0,
+          n_x = NULL,
+          n_cats_x = NULL,
+          max_chars_labels_x = NULL,
+          max_chars_cats_x = NULL,
+          fixed_constant = max_value, # Use max as the base height
+          multiplier_per_plot = 0, # Disable scaling
+          max = max_value,
+          min = min_value
+        )
+      )
     }
 
     # TODO: Should find a more robust way to identify the indep variable

--- a/man/fig_height_h_barchart2.Rd
+++ b/man/fig_height_h_barchart2.Rd
@@ -22,7 +22,7 @@ fig_height_h_barchart2(
   fixed_constant = 0,
   figure_width_in_cm = 14,
   margin_in_cm = 0,
-  max = 8,
+  max = 12,
   min = 1
 )
 }

--- a/tests/testthat/test-fig_height_h_barchart.R
+++ b/tests/testthat/test-fig_height_h_barchart.R
@@ -120,3 +120,37 @@ testthat::test_that("fig_height_h_barchart respects min and max height", {
   )
   testthat::expect_equal(result, 6)
 })
+
+testthat::test_that("fig_height_h_barchart2 returns default for int_plot_html with indep", {
+  plot <- saros::makeme(
+    data = saros::ex_survey,
+    dep = c_1:c_2,
+    indep = b_1,
+    type = "int_plot_html"
+  )
+  result <- saros::fig_height_h_barchart2(plot)
+  testthat::expect_equal(result, 12)
+})
+
+testthat::test_that("fig_height_h_barchart2 returns default for int_plot_html without indep", {
+  plot <- saros::makeme(
+    data = saros::ex_survey,
+    dep = c_1:c_2,
+    type = "int_plot_html"
+  )
+  result <- saros::fig_height_h_barchart2(plot)
+  testthat::expect_equal(result, 12)
+})
+
+testthat::test_that("fig_height_h_barchart2 works for cat_plot_html", {
+  plot <- saros::makeme(
+    data = saros::ex_survey,
+    dep = b_1:b_2,
+    indep = x1_sex,
+    type = "cat_plot_html"
+  )
+  result <- saros::fig_height_h_barchart2(plot)
+  # Should return a calculated height, not default
+  testthat::expect_type(result, "double")
+  testthat::expect_true(result > 0)
+})


### PR DESCRIPTION
…ables

Previously, calling fig_height_h_barchart2() on int_plot_html output with an independent variable would error with 'only supports a single indep variable'.

Now forwards to fig_height_h_barchart() with appropriate parameters, returning the max parameter value (default 12) for interval plots while allowing user customization via the max parameter.

- Changed default max from 8 to 12 in fig_height_h_barchart2()
- Added early detection for int_plot_html (has .value, not .category)
- Forwards to fig_height_h_barchart() using fixed_constant=max_value
- Added 3 tests covering int_plot_html with/without indep and cat_plot_html
- Updated NEWS.md with bug fix entry

Fixes issue where int_plot_html plots couldn't use fig_height_h_barchart2().