### PR TITLE
Fix girafe() to return static plots in non-HTML knitr documents

### DIFF
--- a/R/girafe.R
+++ b/R/girafe.R
@@ -136,7 +136,13 @@ girafe <- function(
         classes = "rlang_message"
       )
 
-    if (isTRUE(interactive)) {
+    # In non-HTML knitr formats (typst, docx, pdf), return static ggplot
+    # to avoid knitr:::html_screenshot() creating leftover temp directories
+    # and to produce higher-quality native raster figures.
+    in_knitr <- isTRUE(getOption("knitr.in.progress"))
+    non_html_doc <- in_knitr && !knitr::is_html_output()
+
+    if (isTRUE(args$interactive) && !non_html_doc) {
       ggiraph::girafe(
         ggobj = ggobj,
         pointsize = args$pointsize,


### PR DESCRIPTION
When rendering in non-HTML knitr formats (docx, pdf, typst), girafe() now returns a static ggplot instead of an interactive ggiraph object.

Benefits:
- Prevents knitr:::html_screenshot() from creating leftover temp directories
- Produces higher-quality native raster figures in docx/pdf outputs
- Avoids unnecessary HTML widget conversion in non-HTML contexts

The fix detects knitr.in.progress and checks knitr::is_html_output() to determine if interactive output should be suppressed.