### PR TITLE
fix: revert to \newpage for page breaks in tabset functions

### DIFF
--- a/R/crowd_plots_as_tabset.R
+++ b/R/crowd_plots_as_tabset.R
@@ -120,6 +120,16 @@ crowd_plots_as_tabset <- function(
     return(invisible(NULL))
   }
 
+  # Error if all non-NULL elements are data frames (tables, not plots)
+  non_null_items <- plot_list[non_null_plots]
+  all_dataframes <- all(vapply(non_null_items, is.data.frame, logical(1)))
+  if (all_dataframes) {
+    cli::cli_abort(c(
+      "{.arg plot_list} contains data frames, not ggplot objects.",
+      "i" = "Use {.fun crowd_tables_as_tabset} for tabulating data frames."
+    ))
+  }
+
   # Match plot_type argument
   plot_type <- match.arg(plot_type)
 
@@ -238,19 +248,17 @@ crowd_plots_as_tabset <- function(
   pagebreak <- match.arg(pagebreak)
   insert_pagebreak <- switch(
     pagebreak,
-    auto = output_format() != "html",
+    auto = !is_html_output_or_officer(),
     always = TRUE,
     never = FALSE
   )
 
-  if (insert_pagebreak && length(out_list) > 1) {
-    interleaved <- list(out_list[[1]])
-    for (i in seq(2, length(out_list))) {
-      interleaved <- c(
-        interleaved,
-        list("\\newpage"),
-        list(out_list[[i]])
-      )
+  n <- length(out_list)
+  if (insert_pagebreak && n > 1) {
+    interleaved <- vector("list", 2L * n - 1L)
+    for (i in seq_along(out_list)) {
+      interleaved[[2L * i - 1L]] <- out_list[[i]]
+      if (i < n) interleaved[[2L * i]] <- "\\newpage"
     }
     out <- unlist(interleaved)
   } else {

--- a/R/crowd_plots_as_tabset.R
+++ b/R/crowd_plots_as_tabset.R
@@ -120,16 +120,6 @@ crowd_plots_as_tabset <- function(
     return(invisible(NULL))
   }
 
-  # Check if user passed table output instead of plot output
-  first_non_null <- plot_list[[which(non_null_plots)[1]]]
-  if (inherits(first_non_null, "data.frame") && !ggplot2::is_ggplot(first_non_null)) {
-    cli::cli_abort(c(
-      "{.arg plot_list} contains data frames (table output), not ggplot objects.",
-      "i" = "{.fn crowd_plots_as_tabset} expects plot output (e.g. from {.code type = \"cat_plot_html\"}).",
-      "i" = "For table output (e.g. from {.code type = \"cat_table_html\"}), use {.fn crowd_tables_as_tabset} instead."
-    ))
-  }
-
   # Match plot_type argument
   plot_type <- match.arg(plot_type)
 
@@ -248,17 +238,19 @@ crowd_plots_as_tabset <- function(
   pagebreak <- match.arg(pagebreak)
   insert_pagebreak <- switch(
     pagebreak,
-    auto = !is_html_output_or_officer(),
+    auto = output_format() != "html",
     always = TRUE,
     never = FALSE
   )
 
   if (insert_pagebreak && length(out_list) > 1) {
-    n <- length(out_list)
-    interleaved <- vector("list", 2L * n - 1L)
-    for (i in seq_along(out_list)) {
-      interleaved[[2L * i - 1L]] <- out_list[[i]]
-      if (i < n) interleaved[[2L * i]] <- "\n\n{{< pagebreak >}}\n\n"
+    interleaved <- list(out_list[[1]])
+    for (i in seq(2, length(out_list))) {
+      interleaved <- c(
+        interleaved,
+        list("\\newpage"),
+        list(out_list[[i]])
+      )
     }
     out <- unlist(interleaved)
   } else {

--- a/R/crowd_tables_as_tabset.R
+++ b/R/crowd_tables_as_tabset.R
@@ -51,9 +51,8 @@ crowd_tables_as_tabset <- function(
     )
 
   pagebreak <- match.arg(args$pagebreak, choices = c("auto", "always", "never"))
-  insert_pagebreak <- switch(
-    pagebreak,
-    auto = !is_html_output_or_officer(),
+  insert_pagebreak <- switch(pagebreak,
+    auto = output_format() != "html",
     always = TRUE,
     never = FALSE
   )
@@ -61,7 +60,7 @@ crowd_tables_as_tabset <- function(
 
   for (i in seq_along(table_names)) {
     if (insert_pagebreak && i > 1) {
-      cat("\n\n{{< pagebreak >}}\n\n")
+      cat("\\newpage\n\n")
     }
     cat(sprintf("##### %s\n", table_names[i]))
     print(args$table_fn(tbl_list[[table_names[i]]]))

--- a/R/crowd_tables_as_tabset.R
+++ b/R/crowd_tables_as_tabset.R
@@ -52,7 +52,7 @@ crowd_tables_as_tabset <- function(
 
   pagebreak <- match.arg(args$pagebreak, choices = c("auto", "always", "never"))
   insert_pagebreak <- switch(pagebreak,
-    auto = output_format() != "html",
+    auto = !is_html_output_or_officer(),
     always = TRUE,
     never = FALSE
   )


### PR DESCRIPTION
## Summary

Reverts `{{< pagebreak >}}` back to `\newpage` for page break insertion in `crowd_plots_as_tabset()` and `crowd_tables_as_tabset()`.

## Problem

The Quarto `{{< pagebreak >}}` shortcode cannot be used inside containers (`panel: tabset`), producing the error:
> "error: pagebreaks are not allowed inside of containers"

## Solution

Switch back to `\newpage` which pandoc handles directly without container restrictions. This works for docx and PDF output formats. Typst doesn't support either approach currently.

Also adds `pagebreak` parameter (`"auto"`, `"always"`, `"never"`) to both functions, defaulting to `"auto"` (insert page breaks for non-HTML formats only).