### PR TITLE
fix: cat_table_* consistently displays 0, NA and "" as empty cells

### DIFF
--- a/R/make_content.cat_table_html.R
+++ b/R/make_content.cat_table_html.R
@@ -50,6 +50,15 @@ make_content.cat_table_html <-
           values_from = ".data_label",
           names_expand = TRUE
         )
+      # Normalize NA and "0" to "" for consistent empty cell display
+      data_out <- dplyr::mutate(
+        data_out,
+        dplyr::across(
+          tidyselect::all_of(cat_lvls),
+          ~ dplyr::if_else(is.na(.x) | .x == "0", "", .x)
+        )
+      )
+
       new_col_order <-
         c(col_basis, dots$indep, cat_lvls, ".count_per_indep_group")
 
@@ -78,6 +87,13 @@ make_content.cat_table_html <-
         c(col_basis, dots$indep, ".category", ".data_label", ".count"),
         drop = FALSE
       ] |>
+        dplyr::mutate(
+          .data_label = dplyr::if_else(
+            is.na(.data$.data_label) | .data$.data_label == "0",
+            "",
+            .data$.data_label
+          )
+        ) |>
         dplyr::rename_with(
           .cols = ".count",
           .fn = function(x) dots$translations$table_heading_N

--- a/tests/testthat/test-make_content.cat_table_html.R
+++ b/tests/testthat/test-make_content.cat_table_html.R
@@ -72,7 +72,7 @@ testthat::test_that("make_content.cat_table_html works with NA on both dep and i
         ordered = TRUE
       ),
       `M (%)` = c("67", "33"),
-      `F (%)` = c(NA, "33"),
+      `F (%)` = c("", "33"),
       `NA (%)` = c("33", "33"),
       `Total (N)` = c(3L, 3L)
     ) |>


### PR DESCRIPTION
## Summary
- After `pivot_wider`, cells with no data showed inconsistently as `"0"`, `NA`, or `""` in `cat_table_html` output
- Now all three are normalized to `""` (empty string) in both wide and long table formats
- The `cat_table_docx` variant inherits this fix since it delegates to `cat_table_html`
- Consistent with how the formatting file (`nifu_global_general_formatting.R`) handles empty cells via `tinytable::format_tt(replace = TRUE)` and `options(knitr.kable.NA = "")`

Closes #524

## Test plan
- [x] `devtools::check()` passes with 0 errors, 0 warnings, 0 notes
- [x] Updated test expectation from `NA` to `""` for the NA-on-both-dep-and-indep case

🤖 Generated with [Claude Code](https://claude.com/claude-code)