### PR TITLE
fix: use as.character() before as.numeric() in crosstable

### DIFF
--- a/R/crosstable.data.frame.R
+++ b/R/crosstable.data.frame.R
@@ -77,7 +77,7 @@ crosstable_prepare_data <- function(data, dep_var, indep, showNA) {
 
 # Helper function: Calculate mean values
 crosstable_calculate_means <- function(data, indep) {
-  data$.mean <- suppressWarnings(as.numeric(data$.category))
+  data$.mean <- suppressWarnings(as.numeric(as.character(data$.category)))
   tryCatch(
     stats::aggregate(
       .mean ~ .,
@@ -94,7 +94,7 @@ crosstable_calculate_means <- function(data, indep) {
 
 # Helper function: Calculate median values
 crosstable_calculate_medians <- function(data, indep) {
-  data$.median <- suppressWarnings(as.numeric(data$.category))
+  data$.median <- suppressWarnings(as.numeric(as.character(data$.category)))
   tryCatch(
     stats::aggregate(
       .median ~ .,


### PR DESCRIPTION
## Summary
- `as.numeric(factor)` returns integer codes (1,2,3), not the label values
- Adding `as.character()` first ensures label text is parsed correctly for mean/median calculation
- `suppressWarnings` kept because non-numeric labels correctly produce NA
- Survey version (`crosstable.survey.R`) unchanged — `srvyr` functions operate on factor codes directly

Closes #577

## Test plan
- [x] `devtools::check()` passes with 0 errors, 0 warnings, 0 notes
- [x] All 46 summarize_cat_cat_data tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)