### PR TITLE
fix: drop dep variables with all-NA data before plot generation

### DIFF
--- a/R/makeme_helpers.R
+++ b/R/makeme_helpers.R
@@ -736,7 +736,7 @@ process_crowd_data <- function(
     dropped <- dep_crwd[all_na_deps]
     cli::cli_warn(c(
       "Dropping {cli::qty(dropped)} variable{?s} with no non-NA data: {.var {dropped}}.",
-      i = "All values are NA after filtering for crowd {.val {crwd}}."
+      i = "All values are NA after applying crowd, indep, and category filters."
     ))
     dep_crwd <- dep_crwd[!all_na_deps]
     if (length(dep_crwd) == 0) {

--- a/R/makeme_helpers.R
+++ b/R/makeme_helpers.R
@@ -726,6 +726,24 @@ process_crowd_data <- function(
     return(NULL)
   }
 
+  # Drop dep variables that have all-NA values in the subset
+  all_na_deps <- vapply(
+    dep_crwd,
+    function(v) all(is.na(subset_data[[v]])),
+    logical(1)
+  )
+  if (any(all_na_deps)) {
+    dropped <- dep_crwd[all_na_deps]
+    cli::cli_warn(c(
+      "Dropping {cli::qty(dropped)} variable{?s} with no non-NA data: {.var {dropped}}.",
+      i = "All values are NA after filtering for crowd {.val {crwd}}."
+    ))
+    dep_crwd <- dep_crwd[!all_na_deps]
+    if (length(dep_crwd) == 0) {
+      return(NULL)
+    }
+  }
+
   # Detect variable types and generate data summary
   variable_types <- detect_variable_types(subset_data, dep_crwd, indep_crwd)
 

--- a/tests/testthat/test-drop_empty_deps.R
+++ b/tests/testthat/test-drop_empty_deps.R
@@ -1,0 +1,111 @@
+testthat::test_that("process_crowd_data drops dep with all-NA in subset_data", {
+  # Create minimal scenario: subset_data has b_2 all-NA,
+  # but omitted_cols_list doesn't include b_2 (simulating bypass of keep_cols)
+  test_data <- saros::ex_survey
+  test_data$b_2 <- NA
+
+  args <- list(
+    data = test_data,
+    dep = c("b_1", "b_2", "b_3"),
+    indep = character(0),
+    type = "cat_table_html",
+    label_separator = " - ",
+    showNA = "never",
+    totals = FALSE,
+    sort_dep_by = ".variable_position",
+    sort_indep_by = ".factor_order",
+    descend = TRUE,
+    descend_indep = FALSE,
+    data_label = "percentage",
+    digits = 0,
+    add_n_to_dep_label = FALSE,
+    add_n_to_indep_label = FALSE,
+    add_n_to_label = FALSE,
+    add_n_to_category = FALSE,
+    hide_label_if_prop_below = 0.01,
+    data_label_decimal_symbol = ".",
+    categories_treated_as_na = character(0),
+    labels_always_at_bottom = character(0),
+    labels_always_at_top = character(0),
+    translations = list(table_heading_N = "Total (N)"),
+    hide_for_all_crowds_if_hidden_for_crowd = NULL,
+    hide_indep_cat_for_all_crowds_if_hidden_for_crowd = FALSE,
+    n_categories_limit = 10,
+    table_main_question_as_header = FALSE,
+    hide_axis_text_if_single_variable = FALSE,
+    error_on_duplicates = FALSE,
+    mesos_var = NULL,
+    mesos_group = NULL
+  )
+
+  testthat::expect_warning(
+    result <- saros:::process_crowd_data(
+      crwd = "all",
+      args = args,
+      omitted_cols_list = list(all = character(0)),
+      kept_indep_cats_list = list(all = list()),
+      data = test_data,
+      mesos_var = NULL,
+      mesos_group = NULL
+    ),
+    regexp = "no non-NA data"
+  )
+  # b_2 dropped, result from b_1 + b_3
+  testthat::expect_true(is.data.frame(result))
+  testthat::expect_gt(nrow(result), 0)
+})
+
+testthat::test_that("process_crowd_data returns NULL when all deps are all-NA", {
+  test_data <- saros::ex_survey
+  test_data$b_1 <- NA
+  test_data$b_2 <- NA
+  test_data$b_3 <- NA
+
+  args <- list(
+    data = test_data,
+    dep = c("b_1", "b_2", "b_3"),
+    indep = character(0),
+    type = "cat_table_html",
+    label_separator = " - ",
+    showNA = "never",
+    totals = FALSE,
+    sort_dep_by = ".variable_position",
+    sort_indep_by = ".factor_order",
+    descend = TRUE,
+    descend_indep = FALSE,
+    data_label = "percentage",
+    digits = 0,
+    add_n_to_dep_label = FALSE,
+    add_n_to_indep_label = FALSE,
+    add_n_to_label = FALSE,
+    add_n_to_category = FALSE,
+    hide_label_if_prop_below = 0.01,
+    data_label_decimal_symbol = ".",
+    categories_treated_as_na = character(0),
+    labels_always_at_bottom = character(0),
+    labels_always_at_top = character(0),
+    translations = list(table_heading_N = "Total (N)"),
+    hide_for_all_crowds_if_hidden_for_crowd = NULL,
+    hide_indep_cat_for_all_crowds_if_hidden_for_crowd = FALSE,
+    n_categories_limit = 10,
+    table_main_question_as_header = FALSE,
+    hide_axis_text_if_single_variable = FALSE,
+    error_on_duplicates = FALSE,
+    mesos_var = NULL,
+    mesos_group = NULL
+  )
+
+  testthat::expect_warning(
+    result <- saros:::process_crowd_data(
+      crwd = "all",
+      args = args,
+      omitted_cols_list = list(all = character(0)),
+      kept_indep_cats_list = list(all = list()),
+      data = test_data,
+      mesos_var = NULL,
+      mesos_group = NULL
+    ),
+    regexp = "no non-NA data"
+  )
+  testthat::expect_null(result)
+})


### PR DESCRIPTION
## Summary
When a dep variable has no non-NA observations after filtering by crowd/indep, it caused plot device failures. Now these variables are dropped with a warning before reaching the plot/table construction.

- Checks each dep variable for all-NA after crowd filtering
- Drops all-NA deps with an informative warning listing the dropped variables
- Skips the entire crowd if no deps remain

Closes #439

## Test plan
- [x] `devtools::check()` passes with Status: OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)