### PR TITLE
feat: add sort_dep_by = '.range' for variability-based sorting

### DIFF
--- a/R/sorting_utils.R
+++ b/R/sorting_utils.R
@@ -260,12 +260,27 @@ add_dep_order <- function(data, sort_by, descend = FALSE) {
     )
   } else if (length(sort_by) == 1 && sort_by == ".range") {
     # Sort by range of proportions (max - min) across categories per variable
+    if (!".proportion" %in% names(data)) {
+      cli::cli_abort(
+        c(
+          x = "{.val .range} sorting requires a {.var .proportion} column.",
+          i = "This output type may not compute proportions. Use a different {.arg sort_dep_by} value."
+        )
+      )
+    }
+    # Aggregate mean proportion per (variable, category) first to handle
+    # bivariate data with multiple indep groups, then compute range per variable
     range_map <- data |>
-      dplyr::group_by(.data$.variable_name) |>
       dplyr::summarize(
-        .range = max(.data$.proportion, na.rm = TRUE) -
-          min(.data$.proportion, na.rm = TRUE),
-        .groups = "drop"
+        .mean_prop = mean(.data$.proportion, na.rm = TRUE),
+        .by = c(".variable_name", ".category")
+      ) |>
+      dplyr::summarize(
+        .range = {
+          vals <- .data$.mean_prop[!is.na(.data$.mean_prop)]
+          if (length(vals) < 2) 0 else max(vals) - min(vals)
+        },
+        .by = ".variable_name"
       ) |>
       arrange_with_order(.data$.range, descend = descend) |>
       dplyr::mutate(order_rank = dplyr::row_number()) |>

--- a/R/sorting_utils.R
+++ b/R/sorting_utils.R
@@ -258,6 +258,23 @@ add_dep_order <- function(data, sort_by, descend = FALSE) {
       sort_by[1],
       descend = descend
     )
+  } else if (length(sort_by) == 1 && sort_by == ".range") {
+    # Sort by range of proportions (max - min) across categories per variable
+    range_map <- data |>
+      dplyr::group_by(.data$.variable_name) |>
+      dplyr::summarize(
+        .range = max(.data$.proportion, na.rm = TRUE) -
+          min(.data$.proportion, na.rm = TRUE),
+        .groups = "drop"
+      ) |>
+      arrange_with_order(.data$.range, descend = descend) |>
+      dplyr::mutate(order_rank = dplyr::row_number()) |>
+      dplyr::select(tidyselect::all_of(c(".variable_name", "order_rank")))
+    data <- dplyr::left_join(
+      data, range_map, by = ".variable_name", relationship = "many-to-one"
+    )
+    data$.dep_order <- data$order_rank
+    data$order_rank <- NULL
   } else if (
     length(sort_by) == 1 && all(sort_by %in% .saros.env$summary_data_sort1)
   ) {

--- a/R/summarize_cat_cat_data.R
+++ b/R/summarize_cat_cat_data.R
@@ -84,7 +84,8 @@ add_collapsed_categories <-
     lvls <- lvls[!lvls %in% categories_treated_as_na]
     if (
       length(sort_by) == 1 &&
-        any(.saros.env$summary_data_sort1 == sort_by)
+        any(.saros.env$summary_data_sort1 == sort_by) &&
+        sort_by != ".range"
     ) {
       sort_by <- subset_vector(vec = lvls, set = sort_by)
     }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -9,7 +9,7 @@ if (!exists(".saros.env")) {
   }
 
   .saros.env$summary_data_sort1 <<-
-    c(".top", ".upper", ".mid_upper", ".lower", ".mid_lower", ".bottom")
+    c(".top", ".upper", ".mid_upper", ".lower", ".mid_lower", ".bottom", ".range")
   .saros.env$summary_data_sort2 <<-
     c(
       # Can this be constructed on the fly from class or crosstable_empty_output()? Or opposite?

--- a/tests/testthat/test-sort_dep_by_range.R
+++ b/tests/testthat/test-sort_dep_by_range.R
@@ -1,0 +1,35 @@
+testthat::test_that("sort_dep_by = '.range' orders variables by proportion range", {
+  result <- saros::makeme(
+    data = saros::ex_survey,
+    dep = b_1:b_3,
+    type = "cat_table_html",
+    sort_dep_by = ".range",
+    descend = TRUE
+  )
+  testthat::expect_true(is.data.frame(result))
+  testthat::expect_gt(nrow(result), 0)
+})
+
+testthat::test_that("sort_dep_by = '.range' with descend = FALSE reverses order", {
+  result_desc <- saros::makeme(
+    data = saros::ex_survey,
+    dep = b_1:b_3,
+    type = "cat_table_html",
+    sort_dep_by = ".range",
+    descend = TRUE
+  )
+  result_asc <- saros::makeme(
+    data = saros::ex_survey,
+    dep = b_1:b_3,
+    type = "cat_table_html",
+    sort_dep_by = ".range",
+    descend = FALSE
+  )
+  # First row labels should differ (reversed order)
+  if (nrow(result_desc) > 1 && nrow(result_asc) > 1) {
+    testthat::expect_true(
+      result_desc[[1]][1] != result_asc[[1]][1] ||
+        result_desc[[1]][nrow(result_desc)] != result_asc[[1]][nrow(result_asc)]
+    )
+  }
+})

--- a/tests/testthat/test-sort_dep_by_range.R
+++ b/tests/testthat/test-sort_dep_by_range.R
@@ -1,35 +1,73 @@
-testthat::test_that("sort_dep_by = '.range' orders variables by proportion range", {
+testthat::test_that("sort_dep_by = '.range' orders by proportion range descending", {
+  # Create synthetic data with known distributions:
+  # var_wide: proportions spread 0.1 to 0.9 -> range 0.8
+  # var_narrow: proportions spread 0.4 to 0.6 -> range 0.2
+  test_data <- data.frame(
+    var_wide = factor(c(rep("A", 9), rep("B", 1)), levels = c("A", "B")),
+    var_narrow = factor(c(rep("A", 6), rep("B", 4)), levels = c("A", "B"))
+  )
+  labelled::var_label(test_data$var_wide) <- "Q1 - Wide spread"
+  labelled::var_label(test_data$var_narrow) <- "Q1 - Narrow spread"
+
   result <- saros::makeme(
-    data = saros::ex_survey,
-    dep = b_1:b_3,
+    data = test_data,
+    dep = var_wide:var_narrow,
     type = "cat_table_html",
     sort_dep_by = ".range",
-    descend = TRUE
+    descend = TRUE,
+    label_separator = " - "
   )
-  testthat::expect_true(is.data.frame(result))
-  testthat::expect_gt(nrow(result), 0)
+  labels <- as.character(result[[1]])
+  # With descend = TRUE, widest range first
+  testthat::expect_equal(labels, c("Wide spread", "Narrow spread"))
 })
 
 testthat::test_that("sort_dep_by = '.range' with descend = FALSE reverses order", {
+  test_data <- data.frame(
+    var_wide = factor(c(rep("A", 9), rep("B", 1)), levels = c("A", "B")),
+    var_narrow = factor(c(rep("A", 6), rep("B", 4)), levels = c("A", "B"))
+  )
+  labelled::var_label(test_data$var_wide) <- "Q1 - Wide spread"
+  labelled::var_label(test_data$var_narrow) <- "Q1 - Narrow spread"
+
   result_desc <- saros::makeme(
-    data = saros::ex_survey,
-    dep = b_1:b_3,
-    type = "cat_table_html",
-    sort_dep_by = ".range",
-    descend = TRUE
+    data = test_data, dep = var_wide:var_narrow,
+    type = "cat_table_html", sort_dep_by = ".range",
+    descend = TRUE, label_separator = " - "
   )
   result_asc <- saros::makeme(
-    data = saros::ex_survey,
-    dep = b_1:b_3,
-    type = "cat_table_html",
-    sort_dep_by = ".range",
-    descend = FALSE
+    data = test_data, dep = var_wide:var_narrow,
+    type = "cat_table_html", sort_dep_by = ".range",
+    descend = FALSE, label_separator = " - "
   )
-  # First row labels should differ (reversed order)
-  if (nrow(result_desc) > 1 && nrow(result_asc) > 1) {
-    testthat::expect_true(
-      result_desc[[1]][1] != result_asc[[1]][1] ||
-        result_desc[[1]][nrow(result_desc)] != result_asc[[1]][nrow(result_asc)]
-    )
-  }
+  labels_desc <- as.character(result_desc[[1]])
+  labels_asc <- as.character(result_asc[[1]])
+  testthat::expect_equal(labels_desc, rev(labels_asc))
+})
+
+testthat::test_that("sort_dep_by = '.range' errors when .proportion is missing", {
+  testthat::expect_error(
+    saros:::add_dep_order(
+      data = data.frame(.variable_name = "a", .category = "A", .count = 1),
+      sort_by = ".range",
+      descend = TRUE
+    ),
+    regexp = "requires.*\\.proportion"
+  )
+})
+
+testthat::test_that("sort_dep_by = '.range' handles all-NA proportions gracefully", {
+  test_data <- data.frame(
+    .variable_name = c("a", "a", "b", "b"),
+    .category = factor(c("A", "B", "A", "B")),
+    .proportion = c(NA, NA, 0.3, 0.7),
+    .variable_position = c(1L, 1L, 2L, 2L)
+  )
+  result <- saros:::add_dep_order(test_data, sort_by = ".range", descend = TRUE)
+  testthat::expect_true(".dep_order" %in% names(result))
+  # Variable "b" has range 0.4, "a" has range 0 (all-NA treated as 0)
+  # With descend = TRUE, "b" should be first (order 1)
+  b_order <- unique(result$.dep_order[result$.variable_name == "b"])
+  a_order <- unique(result$.dep_order[result$.variable_name == "a"])
+  testthat::expect_true(b_order < a_order)
 })


### PR DESCRIPTION
## Summary
Adds `sort_dep_by = ".range"` to order dependent variables by the range (max - min) of their category proportions. Variables with the widest spread appear first when `descend = TRUE`.

- Added `.range` to `summary_data_sort1` in `zzz.R`
- New branch in `add_dep_order()` groups by variable, calculates `max(.proportion) - min(.proportion)`
- Excluded `.range` from `subset_vector()` path in `add_collapsed_categories()` (since it's a per-variable statistic, not a positional category method)
- 3 tests

Closes #494

## Test plan
- [x] `devtools::check()` passes with 0 errors, 0 warnings, 0 notes
- [x] All existing sorting tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)